### PR TITLE
Feature/upsert identical hash

### DIFF
--- a/apps/grpc_server/lib/grpc_server/file_system_service/server.ex
+++ b/apps/grpc_server/lib/grpc_server/file_system_service/server.ex
@@ -194,7 +194,7 @@ defmodule GrpcServer.FileSystemService.Server do
 
   # Handle virtual inode removal with reference counting
   # The VFS.remove function now handles nlink decrement automatically
-  defp handle_virtual_inode_remove(inode, virtual_inode_id, parent_id, name) do
+  defp handle_virtual_inode_remove(_inode, virtual_inode_id, parent_id, name) do
     VFS.Repo.transact(fn ->
       case SyncEngine.Torrents.get_torrent_file_by_id(virtual_inode_id) do
         {:ok, torrent_file} ->
@@ -567,7 +567,7 @@ defmodule GrpcServer.FileSystemService.Server do
 
   # Gets the cached download URL if valid, otherwise fetches a new one from Real Debrid
   defp get_or_fetch_download_url(torrent_file) do
-    if SyncEngine.Schemas.TorrentFile.link_valid?(torrent_file) do
+    if TorrentFile.link_valid?(torrent_file) do
       {:ok, torrent_file.download_link}
     else
       fetch_and_cache_download_url(torrent_file)
@@ -583,7 +583,7 @@ defmodule GrpcServer.FileSystemService.Server do
 
     with {:ok, response} <- RealDebrid.Api.UnrestrictLink.unrestrict(client, torrent_file.link),
          changeset <-
-           SyncEngine.Schemas.TorrentFile.cache_link_changeset(torrent_file, response.download),
+           TorrentFile.cache_link_changeset(torrent_file, response.download),
          {:ok, updated_file} <- SyncEngine.Torrents.update_torrent_file(changeset) do
       {:ok, updated_file.download_link}
     else

--- a/apps/grpc_server/lib/grpc_server/file_system_service/server.ex
+++ b/apps/grpc_server/lib/grpc_server/file_system_service/server.ex
@@ -231,12 +231,6 @@ defmodule GrpcServer.FileSystemService.Server do
     end
   end
 
-  # Check if all files in a torrent instance have zero hardlinks
-  # Delegated to DeletionPolicy module for consistency
-  defp check_should_delete_torrent(torrent_hash, torrent_rd_id) do
-    SyncEngine.Services.DeletionPolicy.should_delete_torrent?(torrent_hash, torrent_rd_id)
-  end
-
   @doc """
   Renames/moves a node.
   """

--- a/apps/grpc_server/lib/grpc_server/file_system_service/server.ex
+++ b/apps/grpc_server/lib/grpc_server/file_system_service/server.ex
@@ -197,17 +197,18 @@ defmodule GrpcServer.FileSystemService.Server do
   defp handle_virtual_inode_remove(inode, virtual_inode_id, parent_id, name) do
     VFS.Repo.transact(fn ->
       case SyncEngine.Torrents.get_torrent_file_by_id(virtual_inode_id) do
-        {:ok, virtual_inode} ->
-          # Check if this is the last link before removing
-          should_delete_torrent = inode.nlink == 1
+        {:ok, torrent_file} ->
+          # Store torrent_rd_id before removal for potential deletion
+          torrent_rd_id = torrent_file.torrent_rd_id
 
-          # Remove the directory entry (VFS handles nlink decrement)
+          # Remove the directory entry (VFS handles nlink decrement and calls decrement_hardlink_count)
           case VFS.remove(parent_id, name, cascade: false) do
             :ok ->
-              # If this was the last hardlink, enqueue torrent deletion
-              if should_delete_torrent do
-                enqueue_torrent_deletion_on_remove(virtual_inode)
-              end
+              # Check if all files in this torrent instance have zero hardlinks
+              SyncEngine.Services.DeletionPolicy.maybe_enqueue_deletion(
+                torrent_file.torrent_hash,
+                torrent_rd_id
+              )
 
               {:ok, :ok}
 
@@ -230,23 +231,10 @@ defmodule GrpcServer.FileSystemService.Server do
     end
   end
 
-  # Enqueue torrent deletion when last hardlink is removed
-  defp enqueue_torrent_deletion_on_remove(virtual_inode) do
-    case SyncEngine.Torrents.get_torrent_by_hash(virtual_inode.torrent_hash) do
-      {:ok, torrent} ->
-        Logger.info(
-          "All hardlinks removed for torrent #{torrent.rd_id}, " <>
-            "enqueueing deletion from RealDebrid"
-        )
-
-        # Queue deletion job
-        SyncEngine.Workers.DeletionWorker.enqueue(torrent.hash)
-        :ok
-
-      {:error, :not_found} ->
-        # Torrent already deleted
-        :ok
-    end
+  # Check if all files in a torrent instance have zero hardlinks
+  # Delegated to DeletionPolicy module for consistency
+  defp check_should_delete_torrent(torrent_hash, torrent_rd_id) do
+    SyncEngine.Services.DeletionPolicy.should_delete_torrent?(torrent_hash, torrent_rd_id)
   end
 
   @doc """

--- a/apps/grpc_server/test/e2e/copy_streamable_hardlink_test.exs
+++ b/apps/grpc_server/test/e2e/copy_streamable_hardlink_test.exs
@@ -57,7 +57,8 @@ defmodule GrpcServer.E2E.CopyStreamableHardlinkTest do
     # Create a torrent_file (virtual inode) with a link (streamable)
     {:ok, torrent_file} =
       VFS.Repo.insert(%TorrentFile{
-        torrent_id: torrent.id,
+        torrent_hash: torrent.hash,
+        torrent_rd_id: torrent.rd_id,
         rd_id: 1,
         path: "/#{filename}",
         bytes: size,

--- a/apps/grpc_server/test/e2e/copy_streamable_hardlink_test.exs
+++ b/apps/grpc_server/test/e2e/copy_streamable_hardlink_test.exs
@@ -18,7 +18,6 @@ defmodule GrpcServer.E2E.CopyStreamableHardlinkTest do
   import GrpcServer.Test.GrpcClientHelper
 
   alias VFS
-  alias VFS.FileMode
   alias SyncEngine.Schemas.{Torrent, TorrentFile}
 
   setup do
@@ -36,7 +35,7 @@ defmodule GrpcServer.E2E.CopyStreamableHardlinkTest do
   end
 
   # Helper to create a streamable virtual inode with a hardlink
-  defp create_streamable_file(root_id, filename, size \\ 5_000_000_000) do
+  defp create_streamable_file(root_id, filename, size) do
     # Create a torrent
     {:ok, torrent} =
       VFS.Repo.insert(%Torrent{

--- a/apps/grpc_server/test/e2e/deletion_test.exs
+++ b/apps/grpc_server/test/e2e/deletion_test.exs
@@ -13,13 +13,7 @@ defmodule GrpcServer.E2E.DeletionTest do
   use ExUnit.Case, async: false
 
   alias VFS
-  alias VFS.Repo
-  alias VFS.FileMode
-
-  alias StreamMountApi.{
-    RemoveRequest,
-    RemoveResponse
-  }
+  alias StreamMountApi.{RemoveRequest, RemoveResponse}
 
   alias GrpcServer.FileSystemService.Server
 

--- a/apps/grpc_server/test/e2e/hard_link_test.exs
+++ b/apps/grpc_server/test/e2e/hard_link_test.exs
@@ -49,7 +49,8 @@ defmodule GrpcServer.E2E.HardLinkTest do
          # Create a torrent_file (virtual inode)
          {:ok, torrent_file} <-
            VFS.Repo.insert(%TorrentFile{
-             torrent_id: torrent.id,
+             torrent_hash: torrent.hash,
+             torrent_rd_id: torrent.rd_id,
              rd_id: 1,
              path: "/#{filename}",
              bytes: 5_000_000,
@@ -457,7 +458,8 @@ defmodule GrpcServer.E2E.HardLinkTest do
       # Create a torrent_file (virtual inode)
       {:ok, torrent_file} =
         VFS.Repo.insert(%TorrentFile{
-          torrent_id: torrent.id,
+          torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           rd_id: 1,
           path: "/video.mkv",
           bytes: 5_000_000,

--- a/apps/sync_engine/lib/sync_engine/job_queue.ex
+++ b/apps/sync_engine/lib/sync_engine/job_queue.ex
@@ -14,8 +14,8 @@ defmodule SyncEngine.JobQueue do
 
   ## Usage
 
-      # Enqueue a deletion
-      SyncEngine.JobQueue.enqueue(:delete_torrent, %{torrent_hash: "abc123..."})
+      # Enqueue a deletion by rd_id
+      SyncEngine.JobQueue.enqueue(:delete_torrent, %{rd_id: "RDID123"})
 
       # Get queue status
       SyncEngine.JobQueue.status()
@@ -43,7 +43,7 @@ defmodule SyncEngine.JobQueue do
 
   ## Examples
 
-      JobQueue.enqueue(:delete_torrent, %{torrent_hash: "abc123..."})
+      JobQueue.enqueue(:delete_torrent, %{rd_id: "RDID123"})
       JobQueue.enqueue(:add_torrent, %{rd_torrent: torrent_data, torrents_root_id: 1})
   """
   def enqueue(job_type, args) when is_atom(job_type) and is_map(args) do
@@ -248,10 +248,10 @@ defmodule SyncEngine.JobQueue do
 
   ## Private Functions
 
-  defp process_job(%{type: :delete_torrent, args: %{torrent_hash: torrent_hash}}) do
-    Logger.info("#{__MODULE__} processing deletion for torrent_hash=#{torrent_hash}")
+  defp process_job(%{type: :delete_torrent, args: %{rd_id: rd_id}}) do
+    Logger.info("#{__MODULE__} processing deletion for rd_id=#{rd_id}")
 
-    case SyncEngine.Torrents.get_torrent_by_hash(torrent_hash) do
+    case SyncEngine.Torrents.get_torrent_by_rd_id(rd_id) do
       {:ok, torrent} ->
         client = SyncEngine.RealDebridClient.get_client()
 
@@ -261,12 +261,12 @@ defmodule SyncEngine.JobQueue do
         case result do
           :ok ->
             Logger.info("#{__MODULE__} deleted torrent #{torrent.rd_id} from API")
-            SyncEngine.Torrents.cleanup_after_deletion(torrent_hash, cascade_hardlinks: true)
+            SyncEngine.Torrents.cleanup_after_deletion_by_rd_id(torrent.rd_id)
 
           {:error, "Not found"} ->
             # Already deleted, just cleanup
             Logger.info("#{__MODULE__} torrent #{torrent.rd_id} already deleted, cleaning up")
-            SyncEngine.Torrents.cleanup_after_deletion(torrent_hash, cascade_hardlinks: true)
+            SyncEngine.Torrents.cleanup_after_deletion_by_rd_id(torrent.rd_id)
 
           {:error, reason} ->
             Logger.error("#{__MODULE__} failed to delete torrent #{torrent.rd_id}: #{inspect(reason)}")
@@ -276,7 +276,7 @@ defmodule SyncEngine.JobQueue do
         end
 
       {:error, :not_found} ->
-        Logger.info("#{__MODULE__} torrent_hash=#{torrent_hash} not found, already deleted")
+        Logger.info("#{__MODULE__} rd_id=#{rd_id} not found, already deleted")
         :ok
     end
   end

--- a/apps/sync_engine/lib/sync_engine/queries/torrent_file_queries.ex
+++ b/apps/sync_engine/lib/sync_engine/queries/torrent_file_queries.ex
@@ -50,14 +50,21 @@ defmodule SyncEngine.Queries.TorrentFileQueries do
 
   This indicates that all user-visible references to the torrent's files
   have been removed, and the torrent can be safely deleted from Real-Debrid.
+
+  Returns false if no files exist (empty torrent or already deleted).
   """
   def all_hardlinks_zero?(hash, torrent_rd_id) do
-    TorrentFile
-    |> where([f], f.torrent_hash == ^hash)
-    |> where([f], f.torrent_rd_id == ^torrent_rd_id)
-    |> select([f], f.hardlink_count)
-    |> Repo.all()
-    |> Enum.all?(&(&1 == 0))
+    hardlink_counts =
+      TorrentFile
+      |> where([f], f.torrent_hash == ^hash)
+      |> where([f], f.torrent_rd_id == ^torrent_rd_id)
+      |> select([f], f.hardlink_count)
+      |> Repo.all()
+
+    case hardlink_counts do
+      [] -> false
+      counts -> Enum.all?(counts, &(&1 == 0))
+    end
   end
 
   @doc """

--- a/apps/sync_engine/lib/sync_engine/queries/torrent_file_queries.ex
+++ b/apps/sync_engine/lib/sync_engine/queries/torrent_file_queries.ex
@@ -1,0 +1,72 @@
+defmodule SyncEngine.Queries.TorrentFileQueries do
+  @moduledoc """
+  Shared query functions for torrent_files table.
+
+  Provides reusable queries for finding, filtering, and analyzing torrent files.
+  """
+
+  import Ecto.Query
+  alias SyncEngine.Schemas.{TorrentFile, Torrent}
+  alias VFS.Repo
+
+  @doc """
+  Finds the most recent torrent_file for a given hash and path.
+
+  Orders by torrent.added (Real-Debrid timestamp) first, then by
+  torrent_file.inserted_at as a tiebreaker.
+
+  Returns nil if no matching files exist.
+  """
+  def find_most_recent(hash, path) do
+    TorrentFile
+    |> where([f], f.torrent_hash == ^hash)
+    |> where([f], f.path == ^path)
+    |> join(:inner, [f], t in Torrent, on: f.torrent_rd_id == t.rd_id)
+    |> order_by([f, t], desc: t.added, desc: f.inserted_at)
+    |> limit(1)
+    |> select([f, _t], f)
+    |> Repo.one()
+  end
+
+  @doc """
+  Finds all torrent_files with the given hash and path, excluding a specific torrent_rd_id.
+
+  Useful for finding "other instances" of the same file when handling deletions.
+  Returns results ordered by most recent first.
+  """
+  def find_others_for_path(hash, path, excluding_rd_id) do
+    TorrentFile
+    |> where([f], f.torrent_hash == ^hash)
+    |> where([f], f.path == ^path)
+    |> where([f], f.torrent_rd_id != ^excluding_rd_id)
+    |> join(:inner, [f], t in Torrent, on: f.torrent_rd_id == t.rd_id)
+    |> order_by([f, t], desc: t.added, desc: f.inserted_at)
+    |> select([f, _t], f)
+    |> Repo.all()
+  end
+
+  @doc """
+  Checks if all files in a torrent instance have zero hardlinks.
+
+  This indicates that all user-visible references to the torrent's files
+  have been removed, and the torrent can be safely deleted from Real-Debrid.
+  """
+  def all_hardlinks_zero?(hash, torrent_rd_id) do
+    TorrentFile
+    |> where([f], f.torrent_hash == ^hash)
+    |> where([f], f.torrent_rd_id == ^torrent_rd_id)
+    |> select([f], f.hardlink_count)
+    |> Repo.all()
+    |> Enum.all?(&(&1 == 0))
+  end
+
+  @doc """
+  Gets all torrent_files for a specific torrent instance (by hash and rd_id).
+  """
+  def get_files_for_torrent(hash, torrent_rd_id) do
+    TorrentFile
+    |> where([f], f.torrent_hash == ^hash)
+    |> where([f], f.torrent_rd_id == ^torrent_rd_id)
+    |> Repo.all()
+  end
+end

--- a/apps/sync_engine/lib/sync_engine/schemas/torrent.ex
+++ b/apps/sync_engine/lib/sync_engine/schemas/torrent.ex
@@ -62,7 +62,7 @@ defmodule SyncEngine.Schemas.Torrent do
     ])
     |> validate_required([:rd_id, :filename, :hash, :bytes])
     |> unique_constraint(:rd_id)
-    |> unique_constraint(:hash)
+    # Note: hash is NOT unique - multiple torrent instances can have the same hash
     |> foreign_key_constraint(:inode_id)
   end
 

--- a/apps/sync_engine/lib/sync_engine/schemas/torrent_file.ex
+++ b/apps/sync_engine/lib/sync_engine/schemas/torrent_file.ex
@@ -28,6 +28,9 @@ defmodule SyncEngine.Schemas.TorrentFile do
     # Relationships - using hash instead of ID for resilience
     # Torrent hash is immutable, while torrent ID can change if torrent is re-added
     field(:torrent_hash, :string)
+    # Track which specific torrent instance (rd_id) this file belongs to
+    # This allows multiple torrent instances with the same hash to coexist
+    field(:torrent_rd_id, :string)
     # Reference to the inode representing this file in VFS
     field(:inode_id, :integer)
 
@@ -44,15 +47,16 @@ defmodule SyncEngine.Schemas.TorrentFile do
       :selected,
       :link,
       :torrent_hash,
+      :torrent_rd_id,
       :inode_id,
       :download_link,
       :link_expires_at,
       :link_fetched_at,
       :hardlink_count
     ])
-    |> validate_required([:rd_id, :path, :bytes, :selected, :torrent_hash])
+    |> validate_required([:rd_id, :path, :bytes, :selected, :torrent_hash, :torrent_rd_id])
     |> validate_number(:hardlink_count, greater_than_or_equal_to: 0)
-    |> unique_constraint([:torrent_hash, :rd_id])
+    |> unique_constraint([:torrent_hash, :torrent_rd_id, :rd_id])
     |> foreign_key_constraint(:inode_id)
   end
 

--- a/apps/sync_engine/lib/sync_engine/services/deletion_policy.ex
+++ b/apps/sync_engine/lib/sync_engine/services/deletion_policy.ex
@@ -1,0 +1,45 @@
+defmodule SyncEngine.Services.DeletionPolicy do
+  @moduledoc """
+  Determines when torrents should be deleted from Real-Debrid.
+
+  Deletion policy: A torrent should be deleted from Real-Debrid when
+  all user-visible references (hardlinks) to its files have been removed.
+  """
+
+  require Logger
+  alias SyncEngine.Queries.TorrentFileQueries
+  alias SyncEngine.Workers.DeletionWorker
+
+  @doc """
+  Checks if a torrent should be deleted from Real-Debrid.
+
+  A torrent should be deleted when all its files have zero hardlinks,
+  meaning no user-visible references exist in the VFS.
+
+  Returns `true` if deletion should proceed, `false` otherwise.
+  """
+  def should_delete_torrent?(hash, torrent_rd_id) do
+    TorrentFileQueries.all_hardlinks_zero?(hash, torrent_rd_id)
+  end
+
+  @doc """
+  Enqueues a torrent deletion if the deletion policy allows it.
+
+  Checks if all hardlinks are removed, and if so, enqueues a deletion job.
+
+  Returns:
+  - `:enqueued` if deletion was queued
+  - `:skipped` if deletion was not needed (hardlinks still exist)
+  """
+  def maybe_enqueue_deletion(hash, torrent_rd_id) do
+    if should_delete_torrent?(hash, torrent_rd_id) do
+      Logger.info("All hardlinks removed for torrent #{torrent_rd_id}, enqueueing deletion from RealDebrid")
+
+      DeletionWorker.enqueue(torrent_rd_id)
+      :enqueued
+    else
+      Logger.debug("Skipping deletion for torrent #{torrent_rd_id} - hardlinks still exist")
+      :skipped
+    end
+  end
+end

--- a/apps/sync_engine/lib/sync_engine/services/inode_manager.ex
+++ b/apps/sync_engine/lib/sync_engine/services/inode_manager.ex
@@ -17,6 +17,8 @@ defmodule SyncEngine.Services.InodeManager do
   1. When adding a duplicate file (merge + upsert)
   2. When deleting a torrent and updating remaining files to point to next most recent
 
+  Skips the update if the inode already points to the most recent file (optimization).
+
   Returns:
   - `{:ok, updated_inode}` if successful
   - `{:error, :no_files_found}` if no torrent_files exist for this hash/path
@@ -30,7 +32,14 @@ defmodule SyncEngine.Services.InodeManager do
         {:error, :no_files_found}
 
       most_recent_file ->
-        update_inode_to_file(inode, most_recent_file)
+        # Skip update if inode already points to the most recent file
+        if inode.virtual_inode_id == most_recent_file.id do
+          Logger.debug("VFS inode #{inode.inode_id} already points to most recent torrent_file #{most_recent_file.id}; skipping update")
+
+          {:ok, inode}
+        else
+          update_inode_to_file(inode, most_recent_file)
+        end
     end
   end
 

--- a/apps/sync_engine/lib/sync_engine/services/inode_manager.ex
+++ b/apps/sync_engine/lib/sync_engine/services/inode_manager.ex
@@ -1,0 +1,58 @@
+defmodule SyncEngine.Services.InodeManager do
+  @moduledoc """
+  Manages VFS inode updates for torrent files.
+
+  Handles the logic of updating VFS inodes to point to the most recent
+  torrent_file when multiple torrent instances share the same file.
+  """
+
+  require Logger
+  alias VFS
+  alias SyncEngine.Queries.TorrentFileQueries
+
+  @doc """
+  Updates a VFS inode to point to the most recent torrent_file for the given hash and path.
+
+  This is used in two scenarios:
+  1. When adding a duplicate file (merge + upsert)
+  2. When deleting a torrent and updating remaining files to point to next most recent
+
+  Returns:
+  - `{:ok, updated_inode}` if successful
+  - `{:error, :no_files_found}` if no torrent_files exist for this hash/path
+  - `{:error, reason}` for other errors
+  """
+  def update_to_most_recent(inode, hash, path) do
+    case TorrentFileQueries.find_most_recent(hash, path) do
+      nil ->
+        Logger.warning("No torrent files found for hash #{hash} path #{path} when updating inode #{inode.inode_id}")
+
+        {:error, :no_files_found}
+
+      most_recent_file ->
+        update_inode_to_file(inode, most_recent_file)
+    end
+  end
+
+  @doc """
+  Updates a VFS inode to point to a specific torrent_file.
+
+  Used when we've already identified which file the inode should point to.
+  """
+  def update_inode_to_file(inode, torrent_file) do
+    case VFS.update_node(inode.inode_id, %{
+           virtual_inode_id: torrent_file.id,
+           size: torrent_file.bytes
+         }) do
+      {:ok, updated_inode} ->
+        Logger.debug("Updated VFS inode #{inode.inode_id} to point to torrent_file #{torrent_file.id}")
+
+        {:ok, updated_inode}
+
+      {:error, reason} = error ->
+        Logger.error("Failed to update VFS inode #{inode.inode_id} to torrent_file #{torrent_file.id}: #{inspect(reason)}")
+
+        error
+    end
+  end
+end

--- a/apps/sync_engine/lib/sync_engine/services/torrent_sync.ex
+++ b/apps/sync_engine/lib/sync_engine/services/torrent_sync.ex
@@ -341,6 +341,9 @@ defmodule SyncEngine.Services.TorrentSync do
     old_torrent_file_id = existing_inode.virtual_inode_id
 
     # Create the new torrent_file record for this torrent instance
+    # Use the existing inode's nlink as the initial hardlink_count to maintain consistency
+    initial_hardlink_count = existing_inode.nlink || 1
+
     with {:ok, new_virtual_inode} <-
            SyncEngine.Torrents.create_torrent_file(%{
              rd_id: rd_file.id,
@@ -351,7 +354,7 @@ defmodule SyncEngine.Services.TorrentSync do
              torrent_hash: torrent.hash,
              torrent_rd_id: torrent.rd_id,
              node_id: nil,
-             hardlink_count: 1
+             hardlink_count: initial_hardlink_count
            }),
          # Update the existing VFS inode to point to the most recent torrent_file
          {:ok, updated_inode} <-

--- a/apps/sync_engine/lib/sync_engine/services/torrent_sync.ex
+++ b/apps/sync_engine/lib/sync_engine/services/torrent_sync.ex
@@ -100,18 +100,18 @@ defmodule SyncEngine.Services.TorrentSync do
          client,
          rd_torrents,
          db_torrents,
-         db_hashes,
+         _db_hashes,
          rejected_torrents,
          torrents_root_id
        ) do
     # Create maps for efficient lookup
     rd_map = Map.new(rd_torrents, fn torrent -> {torrent.id, torrent} end)
 
-    # Find torrents to add (in RD but not in DB and not rejected)
+    # With new schema: multiple torrents can have same hash with different rd_ids
+    # No merge needed - just add any rd_id not already in DB
     to_add =
       Map.keys(rd_map)
       |> Enum.reject(fn rd_id -> Map.has_key?(db_torrents, rd_id) end)
-      |> Enum.reject(fn rd_id -> Map.has_key?(db_hashes, Map.get(rd_map, rd_id).hash) end)
       |> Enum.reject(fn rd_id -> Map.has_key?(rejected_torrents, rd_id) end)
 
     # Find torrents to remove (in DB but not in RD)
@@ -276,12 +276,36 @@ defmodule SyncEngine.Services.TorrentSync do
     normalized_path = String.trim_leading(rd_file.path, "/")
     path_parts = Path.split(normalized_path)
     filename = List.last(path_parts)
+    sanitized_filename = sanitize_filename(filename)
     dir_parts = Enum.slice(path_parts, 0..-2//1)
 
     # Create directory structure if needed
-    with {:ok, parent_node} <- ensure_directory_structure(torrent_node.inode_id, dir_parts),
-         # Create virtual inode first (without VFS node)
-         {:ok, virtual_inode} <-
+    with {:ok, parent_node} <- ensure_directory_structure(torrent_node.inode_id, dir_parts) do
+      # Check if a file with this name already exists in this directory
+      case VFS.lookup(parent_node, sanitized_filename) do
+        {:ok, existing_inode} ->
+          # File already exists - merge and upsert behavior
+          handle_existing_file(
+            torrent,
+            parent_node,
+            sanitized_filename,
+            existing_inode,
+            rd_file,
+            link
+          )
+
+        {:error, :not_found} ->
+          # File doesn't exist - create new
+          create_new_file(torrent, parent_node, sanitized_filename, rd_file, link)
+      end
+    else
+      error -> error
+    end
+  end
+
+  defp create_new_file(torrent, parent_node, sanitized_filename, rd_file, link) do
+    # Create virtual inode first (without VFS node)
+    with {:ok, virtual_inode} <-
            SyncEngine.Torrents.create_torrent_file(%{
              rd_id: rd_file.id,
              path: rd_file.path,
@@ -289,6 +313,7 @@ defmodule SyncEngine.Services.TorrentSync do
              selected: rd_file.selected,
              link: link,
              torrent_hash: torrent.hash,
+             torrent_rd_id: torrent.rd_id,
              node_id: nil,
              hardlink_count: 1
            }),
@@ -296,11 +321,46 @@ defmodule SyncEngine.Services.TorrentSync do
          {:ok, _hardlink_node} <-
            VFS.create_hardlink_to_virtual_inode(
              parent_node,
-             sanitize_filename(filename),
+             sanitized_filename,
              virtual_inode.id,
              size: rd_file.bytes
            ) do
       {:ok, virtual_inode}
+    else
+      error -> error
+    end
+  end
+
+  defp handle_existing_file(
+         torrent,
+         _parent_node,
+         _sanitized_filename,
+         existing_inode,
+         rd_file,
+         link
+       ) do
+    # File already exists - this is the merge + upsert case
+    # Create the new torrent_file record for this torrent instance
+    with {:ok, new_virtual_inode} <-
+           SyncEngine.Torrents.create_torrent_file(%{
+             rd_id: rd_file.id,
+             path: rd_file.path,
+             bytes: rd_file.bytes,
+             selected: rd_file.selected,
+             link: link,
+             torrent_hash: torrent.hash,
+             torrent_rd_id: torrent.rd_id,
+             node_id: nil,
+             hardlink_count: 1
+           }),
+         # Update the existing VFS inode to point to the most recent torrent_file
+         {:ok, _updated_inode} <-
+           SyncEngine.Services.InodeManager.update_to_most_recent(
+             existing_inode,
+             torrent.hash,
+             rd_file.path
+           ) do
+      {:ok, new_virtual_inode}
     else
       error -> error
     end
@@ -389,7 +449,7 @@ defmodule SyncEngine.Services.TorrentSync do
         if not MapSet.member?(api_ids_set, torrent.rd_id) do
           # Torrent is gone from API, clean it up locally
           Logger.info("Reconciling deletion for torrent #{torrent.rd_id} - already gone from API")
-          SyncEngine.Torrents.cleanup_after_deletion(torrent.hash, cascade_hardlinks: true)
+          SyncEngine.Torrents.cleanup_after_deletion_by_rd_id(torrent.rd_id)
         else
           :skip
         end
@@ -428,13 +488,13 @@ defmodule SyncEngine.Services.TorrentSync do
         case result do
           :ok ->
             Logger.info("Retry successful for torrent #{torrent.rd_id}")
-            SyncEngine.Torrents.cleanup_after_deletion(torrent.hash, cascade_hardlinks: true)
+            SyncEngine.Torrents.cleanup_after_deletion_by_rd_id(torrent.rd_id)
             {:success, torrent.hash}
 
           {:error, "Not found"} ->
             # Already deleted from API, just cleanup
             Logger.info("Torrent #{torrent.rd_id} already deleted, cleaning up")
-            SyncEngine.Torrents.cleanup_after_deletion(torrent.hash, cascade_hardlinks: true)
+            SyncEngine.Torrents.cleanup_after_deletion_by_rd_id(torrent.rd_id)
             {:success, torrent.hash}
 
           {:error, reason} ->
@@ -472,7 +532,7 @@ defmodule SyncEngine.Services.TorrentSync do
         case RealDebrid.Api.Delete.delete(client, torrent.rd_id) do
           :ok ->
             # Deletion succeeded, clean up local records
-            SyncEngine.Torrents.cleanup_after_deletion(torrent.hash, cascade_hardlinks: true)
+            SyncEngine.Torrents.cleanup_after_deletion_by_rd_id(torrent.rd_id)
             {:ok, torrent.hash}
 
           {:error, reason} ->

--- a/apps/sync_engine/lib/sync_engine/services/torrent_sync.ex
+++ b/apps/sync_engine/lib/sync_engine/services/torrent_sync.ex
@@ -39,14 +39,13 @@ defmodule SyncEngine.Services.TorrentSync do
     verify = Keyword.get(opts, :verify, true)
 
     with {:ok, rd_torrents} <- fetch_rd_torrents(client),
-         {:ok, {db_torrents, db_hashes, rejected_torrents}} <- fetch_db_torrents() do
+         {:ok, {db_torrents, rejected_torrents}} <- fetch_db_torrents() do
       # Compare and sync
       result =
         perform_sync(
           client,
           rd_torrents,
           db_torrents,
-          db_hashes,
           rejected_torrents,
           torrents_root_id
         )
@@ -91,16 +90,14 @@ defmodule SyncEngine.Services.TorrentSync do
 
   defp fetch_db_torrents do
     torrents = SyncEngine.Torrents.get_torrents_by_rd_id()
-    hashes = SyncEngine.Torrents.get_torrents_by_hash()
     rejected = SyncEngine.Torrents.get_rejected_torrents_by_rd_id()
-    {:ok, {torrents, hashes, rejected}}
+    {:ok, {torrents, rejected}}
   end
 
   defp perform_sync(
          client,
          rd_torrents,
          db_torrents,
-         _db_hashes,
          rejected_torrents,
          torrents_root_id
        ) do
@@ -340,6 +337,9 @@ defmodule SyncEngine.Services.TorrentSync do
          link
        ) do
     # File already exists - this is the merge + upsert case
+    # Get the old torrent_file that this inode currently points to (if any)
+    old_torrent_file_id = existing_inode.virtual_inode_id
+
     # Create the new torrent_file record for this torrent instance
     with {:ok, new_virtual_inode} <-
            SyncEngine.Torrents.create_torrent_file(%{
@@ -354,12 +354,24 @@ defmodule SyncEngine.Services.TorrentSync do
              hardlink_count: 1
            }),
          # Update the existing VFS inode to point to the most recent torrent_file
-         {:ok, _updated_inode} <-
+         {:ok, updated_inode} <-
            SyncEngine.Services.InodeManager.update_to_most_recent(
              existing_inode,
              torrent.hash,
              rd_file.path
            ) do
+      # Decrement hardlink_count on the old torrent_file if it changed
+      if old_torrent_file_id && old_torrent_file_id != updated_inode.virtual_inode_id do
+        case SyncEngine.Torrents.get_torrent_file_by_id(old_torrent_file_id) do
+          {:ok, old_file} ->
+            SyncEngine.Torrents.decrement_hardlink_count(old_file)
+
+          {:error, :not_found} ->
+            # Old file already deleted, nothing to decrement
+            :ok
+        end
+      end
+
       {:ok, new_virtual_inode}
     else
       error -> error

--- a/apps/sync_engine/lib/sync_engine/torrents.ex
+++ b/apps/sync_engine/lib/sync_engine/torrents.ex
@@ -59,6 +59,9 @@ defmodule SyncEngine.Torrents do
 
   @doc """
   Creates a torrent.
+
+  Note: Multiple torrents can have the same hash (different rd_ids).
+  rd_id is unique per torrent instance.
   """
   def create_torrent(attrs) do
     %Torrent{}
@@ -106,7 +109,7 @@ defmodule SyncEngine.Torrents do
   @doc """
   Creates a torrent file with merge and conditional upsert logic.
 
-  Uses a merge strategy: attempts to insert, and on conflict (same torrent_hash + rd_id),
+  Uses a merge strategy: attempts to insert, and on conflict (same torrent_hash + torrent_rd_id + rd_id),
   merges the data by updating only specific fields if the new entry has a newer timestamp.
   This prevents losing newer data when the same torrent is re-added to Real-Debrid.
   """
@@ -116,11 +119,11 @@ defmodule SyncEngine.Torrents do
       |> TorrentFile.changeset(attrs)
 
     # Merge strategy: on conflict, upsert with selected fields
-    # The unique constraint is on [:torrent_hash, :rd_id]
+    # The unique constraint is on [:torrent_hash, :torrent_rd_id, :rd_id]
     # Use :replace_all for the upsert to handle merge scenarios
     Repo.insert(changeset,
       on_conflict: :replace_all,
-      conflict_target: [:torrent_hash, :rd_id]
+      conflict_target: [:torrent_hash, :torrent_rd_id, :rd_id]
     )
   end
 
@@ -260,11 +263,11 @@ defmodule SyncEngine.Torrents do
   # --- Deletion Operations ---
 
   @doc """
-  Marks a torrent for deletion by hash.
+  Marks a torrent for deletion by Real Debrid ID.
   Sets deletion_status to "pending_deletion" and records the timestamp.
   """
-  def mark_for_deletion(torrent_hash) when is_binary(torrent_hash) do
-    case get_torrent_by_hash(torrent_hash) do
+  def mark_for_deletion(rd_id) when is_binary(rd_id) do
+    case get_torrent_by_rd_id(rd_id) do
       {:ok, torrent} ->
         torrent
         |> Ecto.Changeset.change(%{
@@ -284,11 +287,11 @@ defmodule SyncEngine.Torrents do
   end
 
   @doc """
-  Queues a torrent deletion job by hash.
+  Queues a torrent deletion job by Real Debrid ID.
   Enqueues a deletion worker job to process the deletion asynchronously.
   """
-  def queue_deletion(torrent_hash) when is_binary(torrent_hash) do
-    SyncEngine.Workers.DeletionWorker.enqueue(torrent_hash)
+  def queue_deletion(rd_id) when is_binary(rd_id) do
+    SyncEngine.Workers.DeletionWorker.enqueue(rd_id)
   end
 
   @doc """
@@ -348,55 +351,42 @@ defmodule SyncEngine.Torrents do
 
   @doc """
   Cleans up a torrent and its associated VFS nodes after successful API deletion.
+  Uses rd_id to identify the specific torrent instance to delete.
 
-  This is called by the sync engine after confirming the torrent is deleted from Real-Debrid.
-
-  In the new hardlink-based model (where TorrentFiles are virtual inodes):
-  - TorrentFiles are virtual inodes with no associated VFS file nodes
-  - Only hardlinks reference virtual inodes via data = "vi:{torrent_file_id}"
-  - All hardlinks pointing to deleted virtual inodes must also be deleted
+  This is the correct function to use for deletion, as it ensures only files
+  belonging to the specific torrent instance (rd_id) are removed, even if
+  multiple torrents with the same hash exist.
 
   It removes:
-  1. All hard links pointing to the torrent's virtual inodes
-  2. All torrent_file records (the virtual inodes themselves)
+  1. All hard links pointing to this torrent instance's virtual inodes
+  2. All torrent_file records belonging to this torrent instance
   3. The torrent record
   4. The parent torrent directory (if empty)
   """
-  def cleanup_after_deletion(torrent_hash, _opts \\ []) when is_binary(torrent_hash) do
+  def cleanup_after_deletion_by_rd_id(rd_id, _opts \\ []) when is_binary(rd_id) do
     Repo.transact(fn ->
-      case get_torrent_by_hash(torrent_hash) do
+      case get_torrent_by_rd_id(rd_id) do
         {:ok, torrent} ->
           # Get the parent directory inode_id (if exists)
           parent_inode_id = torrent.inode_id
 
-          # Get all torrent files by hash
-          torrent_files = list_torrent_files(torrent.hash)
+          # Get all torrent files belonging to THIS SPECIFIC torrent instance
+          torrent_files =
+            SyncEngine.Queries.TorrentFileQueries.get_files_for_torrent(
+              torrent.hash,
+              torrent.rd_id
+            )
 
-          # Delete all directory entries (hardlinks) pointing to this torrent's virtual inode files
-          # The virtual inodes are being deleted, so hardlinks can't exist without them
+          # Handle directory entries (hardlinks) pointing to this torrent's files
+          # With merge logic, files might be shared between multiple torrent instances
           Enum.each(torrent_files, fn torrent_file ->
-            # Find all directory entries pointing to inodes with this virtual_inode_id
-            # These are the hardlinks to this torrent file
-            hardlink_entries =
-              VFS.DirectoryEntry
-              |> join(:inner, [directory_entry], inode in VFS.Inode, on: directory_entry.inode_id == inode.inode_id)
-              |> where([directory_entry, inode], inode.virtual_inode_type == "torrent_file")
-              |> where([directory_entry, inode], inode.virtual_inode_id == ^torrent_file.id)
-              |> select([directory_entry, _inode], directory_entry)
-              |> Repo.all()
-
-            # Delete each hardlink entry (this will decrement nlink and delete inode if nlink reaches 0)
-            Enum.each(hardlink_entries, fn entry ->
-              case VFS.remove(entry.parent_inode_id, entry.name) do
-                :ok -> :ok
-                {:error, _} -> :ok
-              end
-            end)
+            cleanup_torrent_file_inodes(torrent_file, torrent)
           end)
 
-          # Delete all torrent_file records (the virtual inodes)
+          # Delete all torrent_file records belonging to THIS SPECIFIC torrent instance
           TorrentFile
-          |> where([torrent_file], torrent_file.torrent_hash == ^torrent_hash)
+          |> where([f], f.torrent_hash == ^torrent.hash)
+          |> where([f], f.torrent_rd_id == ^torrent.rd_id)
           |> Repo.delete_all()
 
           # Delete the torrent record
@@ -451,15 +441,15 @@ defmodule SyncEngine.Torrents do
   end
 
   @doc """
-  Batch deletes multiple torrents by hash.
+  Batch deletes multiple torrents by Real Debrid ID.
   Marks all torrents for deletion and queues deletion jobs.
   """
-  def batch_delete(torrent_hashes) when is_list(torrent_hashes) do
+  def batch_delete(rd_ids) when is_list(rd_ids) do
     # Mark all torrents for deletion first
-    Enum.each(torrent_hashes, &mark_for_deletion/1)
+    Enum.each(rd_ids, &mark_for_deletion/1)
 
     # Enqueue all deletion jobs in batch
-    SyncEngine.Workers.DeletionWorker.enqueue_batch(torrent_hashes)
+    SyncEngine.Workers.DeletionWorker.enqueue_batch(rd_ids)
   end
 
   # --- Virtual Inode Hardlink Management ---
@@ -476,10 +466,11 @@ defmodule SyncEngine.Torrents do
 
   @doc """
   Decrements the hardlink count for a virtual inode.
-  Returns {new_count, should_delete_torrent}.
+  Returns {new_count, should_delete_torrent, torrent_rd_id}.
 
-  should_delete_torrent is true only when ALL files in the torrent have hardlink_count == 0.
-  This ensures we only delete the torrent from Remote Debrid when no hardlinks exist for any of its files.
+  should_delete_torrent is true only when ALL files in this specific torrent instance
+  have hardlink_count == 0. This ensures we only delete the torrent from Real Debrid 
+  when no hardlinks exist for any of its files.
 
   Called when a hardlink is unlinked by the user.
 
@@ -498,25 +489,30 @@ defmodule SyncEngine.Torrents do
 
       case Repo.update(changeset) do
         {:ok, updated} ->
-          # Now check if ALL files in the torrent have hardlink_count == 0
-          # This query is atomic within the transaction
+          # Now check if ALL files in THIS SPECIFIC torrent instance have hardlink_count == 0
+          # Filter by both hash AND torrent_rd_id to only check files from this torrent instance
           query =
             TorrentFile
             |> where([torrent_file], torrent_file.torrent_hash == ^updated.torrent_hash)
+            |> where([torrent_file], torrent_file.torrent_rd_id == ^updated.torrent_rd_id)
             |> select([torrent_file], torrent_file.hardlink_count)
 
           counts = Repo.all(query)
           should_delete = Enum.all?(counts, &(&1 == 0))
 
-          {:ok, {new_count, should_delete}}
+          # Return the torrent_rd_id so caller knows which torrent to delete
+          {:ok, {new_count, should_delete, updated.torrent_rd_id}}
 
         {:error, reason} ->
           Repo.rollback(reason)
       end
     end)
     |> case do
-      {:ok, {new_count, should_delete}} -> {:ok, {new_count, should_delete}}
-      {:error, reason} -> {:error, reason}
+      {:ok, {new_count, should_delete, torrent_rd_id}} ->
+        {:ok, {new_count, should_delete, torrent_rd_id}}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -547,6 +543,69 @@ defmodule SyncEngine.Torrents do
     case Repo.get(TorrentFile, id) do
       nil -> {:error, :not_found}
       file -> {:ok, file}
+    end
+  end
+
+  # --- Private Helper Functions ---
+
+  # Cleans up VFS inodes for a torrent_file being deleted
+  defp cleanup_torrent_file_inodes(torrent_file, torrent) do
+    # Find all inodes pointing to this virtual_inode_id
+    inodes =
+      VFS.Inode
+      |> where([inode], inode.virtual_inode_type == "torrent_file")
+      |> where([inode], inode.virtual_inode_id == ^torrent_file.id)
+      |> Repo.all()
+
+    # For each inode, check if there are other torrent_files with same hash + path
+    Enum.each(inodes, fn inode ->
+      handle_inode_cleanup(inode, torrent_file, torrent)
+    end)
+  end
+
+  # Handles cleanup for a single inode - either delete it or update to next version
+  defp handle_inode_cleanup(inode, torrent_file, torrent) do
+    # Find other torrent_files (excluding the one being deleted) with same hash + path
+    other_files =
+      SyncEngine.Queries.TorrentFileQueries.find_others_for_path(
+        torrent_file.torrent_hash,
+        torrent_file.path,
+        torrent.rd_id
+      )
+
+    case other_files do
+      [] ->
+        # No other files - safe to delete the inode (and its directory entries)
+        delete_inode_and_entries(inode)
+
+      [most_recent | _] ->
+        # Other files exist - update inode to point to most recent
+        update_inode_to_replacement(inode, most_recent)
+    end
+  end
+
+  # Deletes a VFS inode and all its directory entries
+  defp delete_inode_and_entries(inode) do
+    # Find all directory entries for this inode
+    entries =
+      VFS.DirectoryEntry
+      |> where([de], de.inode_id == ^inode.inode_id)
+      |> Repo.all()
+
+    # Delete each entry
+    Enum.each(entries, fn entry ->
+      case VFS.remove(entry.parent_inode_id, entry.name) do
+        :ok -> :ok
+        {:error, _} -> :ok
+      end
+    end)
+  end
+
+  # Updates a VFS inode to point to a replacement torrent_file
+  defp update_inode_to_replacement(inode, replacement_file) do
+    case SyncEngine.Services.InodeManager.update_inode_to_file(inode, replacement_file) do
+      {:ok, _} -> :ok
+      {:error, _} -> :ok
     end
   end
 end

--- a/apps/sync_engine/lib/sync_engine/torrents.ex
+++ b/apps/sync_engine/lib/sync_engine/torrents.ex
@@ -110,8 +110,8 @@ defmodule SyncEngine.Torrents do
   Creates a torrent file with merge and conditional upsert logic.
 
   Uses a merge strategy: attempts to insert, and on conflict (same torrent_hash + torrent_rd_id + rd_id),
-  merges the data by updating only specific fields if the new entry has a newer timestamp.
-  This prevents losing newer data when the same torrent is re-added to Real-Debrid.
+  merges the data by updating only specific fields while preserving hardlink_count.
+  This prevents losing hardlink tracking when the same torrent is re-added to Real-Debrid.
   """
   def create_torrent_file(attrs) do
     changeset =
@@ -120,9 +120,9 @@ defmodule SyncEngine.Torrents do
 
     # Merge strategy: on conflict, upsert with selected fields
     # The unique constraint is on [:torrent_hash, :torrent_rd_id, :rd_id]
-    # Use :replace_all for the upsert to handle merge scenarios
+    # Preserve hardlink_count to avoid resetting reference tracking
     Repo.insert(changeset,
-      on_conflict: :replace_all,
+      on_conflict: {:replace, [:path, :bytes, :selected, :link, :updated_at]},
       conflict_target: [:torrent_hash, :torrent_rd_id, :rd_id]
     )
   end
@@ -602,10 +602,16 @@ defmodule SyncEngine.Torrents do
   end
 
   # Updates a VFS inode to point to a replacement torrent_file
+  # Also increments the hardlink_count of the replacement file
   defp update_inode_to_replacement(inode, replacement_file) do
     case SyncEngine.Services.InodeManager.update_inode_to_file(inode, replacement_file) do
-      {:ok, _} -> :ok
-      {:error, _} -> :ok
+      {:ok, _} ->
+        # Increment hardlink_count on the replacement file since inode now points to it
+        increment_hardlink_count(replacement_file)
+        :ok
+
+      {:error, _} ->
+        :ok
     end
   end
 end

--- a/apps/sync_engine/lib/sync_engine/torrents.ex
+++ b/apps/sync_engine/lib/sync_engine/torrents.ex
@@ -107,7 +107,7 @@ defmodule SyncEngine.Torrents do
   Creates a torrent file with merge and conditional upsert logic.
 
   Uses a merge strategy: attempts to insert, and on conflict (same torrent_hash + rd_id),
-  only updates the existing entry if the new data has a more recent timestamp.
+  merges the data by updating only specific fields if the new entry has a newer timestamp.
   This prevents losing newer data when the same torrent is re-added to Real-Debrid.
   """
   def create_torrent_file(attrs) do
@@ -115,10 +115,11 @@ defmodule SyncEngine.Torrents do
       %TorrentFile{}
       |> TorrentFile.changeset(attrs)
 
-    # Merge strategy: on conflict, only upsert if new entry is newer
+    # Merge strategy: on conflict, upsert with selected fields
     # The unique constraint is on [:torrent_hash, :rd_id]
+    # Use :replace_all for the upsert to handle merge scenarios
     Repo.insert(changeset,
-      on_conflict: {:replace, [:path, :bytes, :selected, :link, :hardlink_count, :updated_at]},
+      on_conflict: :replace_all,
       conflict_target: [:torrent_hash, :rd_id]
     )
   end

--- a/apps/sync_engine/lib/sync_engine/torrents.ex
+++ b/apps/sync_engine/lib/sync_engine/torrents.ex
@@ -128,16 +128,6 @@ defmodule SyncEngine.Torrents do
   end
 
   @doc """
-  Gets a torrent file by torrent_hash and rd_id.
-  """
-  def get_torrent_file(torrent_hash, rd_id) when is_binary(torrent_hash) do
-    case Repo.get_by(TorrentFile, torrent_hash: torrent_hash, rd_id: rd_id) do
-      nil -> {:error, :not_found}
-      file -> {:ok, file}
-    end
-  end
-
-  @doc """
   Gets a torrent file by node_id.
   """
   def get_torrent_file_by_node_id(node_id) do

--- a/apps/sync_engine/lib/sync_engine/workers/deletion_worker.ex
+++ b/apps/sync_engine/lib/sync_engine/workers/deletion_worker.ex
@@ -7,38 +7,38 @@ defmodule SyncEngine.Workers.DeletionWorker do
 
   ## Usage
 
-      # Delete a single torrent
-      DeletionWorker.enqueue("abc123...")
+      # Delete a single torrent by rd_id
+      DeletionWorker.enqueue("RDID123")
 
       # Delete multiple torrents
-      DeletionWorker.enqueue_batch(["abc123...", "def456..."])
+      DeletionWorker.enqueue_batch(["RDID123", "RDID456"])
   """
 
   @doc """
-  Enqueues a deletion job for a torrent by hash.
+  Enqueues a deletion job for a torrent by rd_id.
 
   ## Examples
 
-      iex> DeletionWorker.enqueue("abc123...")
+      iex> DeletionWorker.enqueue("RDID123")
       :ok
 
   """
-  def enqueue(torrent_hash) when is_binary(torrent_hash) do
-    SyncEngine.JobQueue.enqueue(:delete_torrent, %{torrent_hash: torrent_hash})
+  def enqueue(rd_id) when is_binary(rd_id) do
+    SyncEngine.JobQueue.enqueue(:delete_torrent, %{rd_id: rd_id})
   end
 
   @doc """
-  Enqueues deletion jobs for multiple torrents by hash.
+  Enqueues deletion jobs for multiple torrents by rd_id.
 
   ## Examples
 
-      iex> DeletionWorker.enqueue_batch(["abc123...", "def456..."])
+      iex> DeletionWorker.enqueue_batch(["RDID123", "RDID456"])
       :ok
 
   """
-  def enqueue_batch(torrent_hashes) when is_list(torrent_hashes) do
-    Enum.each(torrent_hashes, fn torrent_hash ->
-      enqueue(torrent_hash)
+  def enqueue_batch(rd_ids) when is_list(rd_ids) do
+    Enum.each(rd_ids, fn rd_id ->
+      enqueue(rd_id)
     end)
 
     :ok

--- a/apps/sync_engine/test/sync_engine/deletion_test.exs
+++ b/apps/sync_engine/test/sync_engine/deletion_test.exs
@@ -75,6 +75,7 @@ defmodule SyncEngine.DeletionTest do
     {:ok, torrent_file} =
       Repo.insert(%TorrentFile{
         torrent_hash: torrent.hash,
+        torrent_rd_id: torrent.rd_id,
         rd_id: 1,
         path: "/movie.mkv",
         bytes: bytes,
@@ -94,8 +95,8 @@ defmodule SyncEngine.DeletionTest do
       # Create a complete torrent fixture
       {torrent, _torrent_dir, _file_node, _torrent_file} = create_torrent_fixture(root)
 
-      # Mark torrent for deletion
-      assert :ok = SyncEngine.Torrents.mark_for_deletion(torrent.hash)
+      # Mark torrent for deletion using rd_id
+      assert :ok = SyncEngine.Torrents.mark_for_deletion(torrent.rd_id)
 
       # Verify status changed
       updated_torrent = Repo.get(Torrent, torrent.id)
@@ -106,11 +107,11 @@ defmodule SyncEngine.DeletionTest do
     test "queues deletion worker job", %{root: root} do
       {torrent, _torrent_dir, _file_node, _torrent_file} = create_torrent_fixture(root)
 
-      # Queue deletion via DeletionWorker
-      assert :ok = SyncEngine.Torrents.queue_deletion(torrent.hash)
+      # Queue deletion via DeletionWorker using rd_id
+      assert :ok = SyncEngine.Torrents.queue_deletion(torrent.rd_id)
 
       # Verify deletion job was enqueued
-      # assert_enqueued worker: SyncEngine.Workers.DeletionWorker, args: %{torrent_hash: torrent.hash}
+      # assert_enqueued worker: SyncEngine.Workers.DeletionWorker, args: %{rd_id: torrent.rd_id}
     end
   end
 
@@ -123,6 +124,7 @@ defmodule SyncEngine.DeletionTest do
       {:ok, torrent_file2} =
         Repo.insert(%TorrentFile{
           torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           rd_id: 2,
           path: "/file2.mkv",
           bytes: 2_000_000,
@@ -132,13 +134,13 @@ defmodule SyncEngine.DeletionTest do
       {:ok, hardlink_node2} =
         VFS.create_hardlink_to_virtual_inode(torrent_dir.inode_id, "file2.mkv", torrent_file2.id)
 
-      # Reload to get the actual torrent_files
-      torrent = Repo.preload(torrent, :files, force: true)
-      [_tf1, _tf2] = torrent.files
+      # Get torrent files by hash (no association, query by hash instead)
+      torrent_files = SyncEngine.Torrents.list_torrent_files(torrent.hash)
+      [_tf1, _tf2] = torrent_files
 
       # Simulate successful API deletion
-      # Now clean up VFS
-      assert :ok = SyncEngine.Torrents.cleanup_after_deletion(torrent.hash)
+      # Now clean up VFS using rd_id
+      assert :ok = SyncEngine.Torrents.cleanup_after_deletion_by_rd_id(torrent.rd_id)
 
       # Verify hardlink VFS nodes are removed
       assert {:error, :not_found} = VFS.get_node(hardlink_node.inode_id)
@@ -276,9 +278,9 @@ defmodule SyncEngine.DeletionTest do
       {:ok, external_hardlink} =
         VFS.create_hardlink_to_virtual_inode(root.inode_id, "favorite.mkv", torrent_file.id)
 
-      # Clean up after deletion
+      # Clean up after deletion using rd_id
       # This should delete all hardlinks pointing to torrent files
-      assert :ok = SyncEngine.Torrents.cleanup_after_deletion(torrent.hash)
+      assert :ok = SyncEngine.Torrents.cleanup_after_deletion_by_rd_id(torrent.rd_id)
 
       # All hardlinks should be deleted
       assert {:error, :not_found} = VFS.get_node(hardlink_node.inode_id)
@@ -292,7 +294,7 @@ defmodule SyncEngine.DeletionTest do
   describe "performance and batching" do
     test "batch deletes multiple torrents efficiently", %{root: root} do
       # Create multiple torrents using fixture
-      torrent_hashes =
+      rd_ids =
         for i <- 1..10 do
           {torrent, _torrent_dir, _file_node, _torrent_file} =
             create_torrent_fixture(root,
@@ -301,15 +303,15 @@ defmodule SyncEngine.DeletionTest do
               filename: "Batch #{i}"
             )
 
-          torrent.hash
+          torrent.rd_id
         end
 
-      # Batch delete - this will mark and queue all deletions
-      assert :ok = SyncEngine.Torrents.batch_delete(torrent_hashes)
+      # Batch delete using rd_ids - this will mark and queue all deletions
+      assert :ok = SyncEngine.Torrents.batch_delete(rd_ids)
 
       # Verify all torrents are marked for deletion
-      for hash <- torrent_hashes do
-        torrent = Repo.get_by(Torrent, hash: hash)
+      for rd_id <- rd_ids do
+        {:ok, torrent} = SyncEngine.Torrents.get_torrent_by_rd_id(rd_id)
         assert torrent.deletion_status == "pending_deletion"
       end
 
@@ -317,13 +319,13 @@ defmodule SyncEngine.DeletionTest do
       # SyncEngine.JobQueue.clear()
 
       # Manually cleanup (simulating successful API deletion)
-      for hash <- torrent_hashes do
-        SyncEngine.Torrents.cleanup_after_deletion(hash)
+      for rd_id <- rd_ids do
+        SyncEngine.Torrents.cleanup_after_deletion_by_rd_id(rd_id)
       end
 
       # Verify all torrents are gone
-      for hash <- torrent_hashes do
-        assert Repo.get_by(Torrent, hash: hash) == nil
+      for rd_id <- rd_ids do
+        assert {:error, :not_found} = SyncEngine.Torrents.get_torrent_by_rd_id(rd_id)
       end
     end
   end

--- a/apps/sync_engine/test/sync_engine/deletion_test.exs
+++ b/apps/sync_engine/test/sync_engine/deletion_test.exs
@@ -134,12 +134,15 @@ defmodule SyncEngine.DeletionTest do
       {:ok, hardlink_node2} =
         VFS.create_hardlink_to_virtual_inode(torrent_dir.inode_id, "file2.mkv", torrent_file2.id)
 
-      # Get torrent files by hash (no association, query by hash instead)
+      # Get all torrent files by hash for verification
+      # Note: In this test there's only one torrent instance with this hash,
+      # so list_torrent_files(hash) is sufficient. In multi-instance scenarios,
+      # use TorrentFileQueries.get_files_for_torrent(hash, rd_id) instead.
       torrent_files = SyncEngine.Torrents.list_torrent_files(torrent.hash)
       [_tf1, _tf2] = torrent_files
 
       # Simulate successful API deletion
-      # Now clean up VFS using rd_id
+      # Now clean up VFS using rd_id (targets specific torrent instance)
       assert :ok = SyncEngine.Torrents.cleanup_after_deletion_by_rd_id(torrent.rd_id)
 
       # Verify hardlink VFS nodes are removed

--- a/apps/sync_engine/test/sync_engine/torrent_file_test.exs
+++ b/apps/sync_engine/test/sync_engine/torrent_file_test.exs
@@ -71,6 +71,7 @@ defmodule SyncEngine.TorrentFileTest do
           bytes: 500,
           selected: 1,
           torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           inode_id: file_node.inode_id
         })
 
@@ -96,6 +97,7 @@ defmodule SyncEngine.TorrentFileTest do
           bytes: 500,
           selected: 1,
           torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           inode_id: file_node.inode_id
         })
 

--- a/apps/sync_engine/test/sync_engine/torrent_verifier_test.exs
+++ b/apps/sync_engine/test/sync_engine/torrent_verifier_test.exs
@@ -40,6 +40,7 @@ defmodule SyncEngine.TorrentVerifierTest do
           bytes: 1000,
           selected: 1,
           torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           inode_id: file_node.inode_id
         })
 
@@ -104,6 +105,7 @@ defmodule SyncEngine.TorrentVerifierTest do
           bytes: 100,
           selected: 1,
           torrent_hash: valid_torrent1.hash,
+          torrent_rd_id: valid_torrent1.rd_id,
           inode_id: valid_file1.inode_id
         })
 
@@ -126,6 +128,7 @@ defmodule SyncEngine.TorrentVerifierTest do
           bytes: 200,
           selected: 1,
           torrent_hash: valid_torrent2.hash,
+          torrent_rd_id: valid_torrent2.rd_id,
           inode_id: valid_file2.inode_id
         })
 
@@ -177,6 +180,7 @@ defmodule SyncEngine.TorrentVerifierTest do
           bytes: 1000,
           selected: 1,
           torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           inode_id: file_node.inode_id
         })
 

--- a/apps/sync_engine/test/sync_engine/torrents_test.exs
+++ b/apps/sync_engine/test/sync_engine/torrents_test.exs
@@ -95,6 +95,47 @@ defmodule SyncEngine.TorrentsTest do
       assert {:error, :not_found} = Torrents.get_torrent_by_rd_id("DELETE_ME")
     end
 
+    test "allows multiple torrents with same hash (different rd_ids)", %{test_dir: test_dir} do
+      {:ok, node1} = VFS.create_directory(test_dir.inode_id, "torrent1")
+      {:ok, node2} = VFS.create_directory(test_dir.inode_id, "torrent2")
+
+      # Create first torrent with hash "same_hash_123"
+      attrs1 = %{
+        rd_id: "RD1",
+        filename: "First Add",
+        hash: "same_hash_123",
+        bytes: 1_000_000,
+        status: "downloaded",
+        inode_id: node1.inode_id
+      }
+
+      {:ok, torrent1} = Torrents.create_torrent(attrs1)
+      assert torrent1.rd_id == "RD1"
+      assert torrent1.hash == "same_hash_123"
+
+      # Create second torrent with same hash but different rd_id
+      attrs2 = %{
+        rd_id: "RD2",
+        filename: "Re-added or Different RD",
+        hash: "same_hash_123",
+        bytes: 1_000_000,
+        status: "magnet_conversion",
+        inode_id: node2.inode_id
+      }
+
+      # This should succeed - multiple torrents can have same hash
+      {:ok, torrent2} = Torrents.create_torrent(attrs2)
+      assert torrent2.rd_id == "RD2"
+      assert torrent2.hash == "same_hash_123"
+
+      # Verify both torrents exist (different IDs)
+      assert torrent1.id != torrent2.id
+
+      # Verify both are in database
+      assert {:ok, _} = Torrents.get_torrent_by_rd_id("RD1")
+      assert {:ok, _} = Torrents.get_torrent_by_rd_id("RD2")
+    end
+
     test "get_torrents_by_rd_id/0 returns map of torrents", %{test_dir: test_dir} do
       {:ok, node1} = VFS.create_directory(test_dir.inode_id, "t1")
       {:ok, node2} = VFS.create_directory(test_dir.inode_id, "t2")
@@ -149,6 +190,7 @@ defmodule SyncEngine.TorrentsTest do
         bytes: 500,
         selected: 1,
         torrent_hash: torrent.hash,
+        torrent_rd_id: torrent.rd_id,
         inode_id: file_node.inode_id
       }
 
@@ -169,6 +211,7 @@ defmodule SyncEngine.TorrentsTest do
           bytes: 500,
           selected: 1,
           torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           inode_id: file_node.inode_id
         })
 
@@ -184,6 +227,7 @@ defmodule SyncEngine.TorrentsTest do
           bytes: 500,
           selected: 1,
           torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           inode_id: file_node.inode_id
         })
 
@@ -200,6 +244,7 @@ defmodule SyncEngine.TorrentsTest do
         bytes: 2_000_000,
         selected: 1,
         torrent_hash: torrent.hash,
+        torrent_rd_id: torrent.rd_id,
         inode_id: nil,
         link: "https://real-debrid.com/unrestrict?link=abc123"
       }
@@ -222,6 +267,7 @@ defmodule SyncEngine.TorrentsTest do
           bytes: 3_000_000,
           selected: 1,
           torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           inode_id: nil,
           link: "https://real-debrid.com/unrestrict?link=def456"
         })
@@ -250,7 +296,7 @@ defmodule SyncEngine.TorrentsTest do
       assert reloaded.hardlink_count == 3
 
       # Decrement: after one decrement, count should be 2
-      {:ok, {new_count, should_delete}} = Torrents.decrement_hardlink_count(reloaded)
+      {:ok, {new_count, should_delete, _rd_id}} = Torrents.decrement_hardlink_count(reloaded)
       assert new_count == 2
       # FALSE because there are still 2 hardlinks remaining
       assert should_delete == false
@@ -269,6 +315,7 @@ defmodule SyncEngine.TorrentsTest do
           bytes: 5_000_000,
           selected: 1,
           torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           inode_id: nil,
           link: "https://real-debrid.com/link1"
         })
@@ -280,18 +327,19 @@ defmodule SyncEngine.TorrentsTest do
           bytes: 100_000,
           selected: 1,
           torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           inode_id: nil,
           link: "https://real-debrid.com/link2"
         })
 
       # Decrement file1: should_delete = false because file2 still has hardlink_count == 1
-      {:ok, {count1, should_delete1}} = Torrents.decrement_hardlink_count(file1)
+      {:ok, {count1, should_delete1, _rd_id}} = Torrents.decrement_hardlink_count(file1)
       assert count1 == 0
       # file2 still has hardlink_count == 1
       assert should_delete1 == false
 
       # Decrement file2: should_delete = true because now ALL files have hardlink_count == 0
-      {:ok, {count2, should_delete2}} = Torrents.decrement_hardlink_count(file2)
+      {:ok, {count2, should_delete2, _rd_id}} = Torrents.decrement_hardlink_count(file2)
       assert count2 == 0
       # NOW all files are at 0
       assert should_delete2 == true
@@ -305,6 +353,7 @@ defmodule SyncEngine.TorrentsTest do
         bytes: 1_000_000,
         selected: 1,
         torrent_hash: torrent.hash,
+        torrent_rd_id: torrent.rd_id,
         inode_id: nil,
         link: "https://real-debrid.com/link_old"
       }
@@ -324,6 +373,7 @@ defmodule SyncEngine.TorrentsTest do
         bytes: 2_000_000,
         selected: 1,
         torrent_hash: torrent.hash,
+        torrent_rd_id: torrent.rd_id,
         inode_id: nil,
         link: "https://real-debrid.com/link_new"
       }
@@ -352,6 +402,7 @@ defmodule SyncEngine.TorrentsTest do
         bytes: 1_000_000,
         selected: 1,
         torrent_hash: torrent.hash,
+        torrent_rd_id: torrent.rd_id,
         link: "https://real-debrid.com/link1"
       }
 
@@ -366,6 +417,7 @@ defmodule SyncEngine.TorrentsTest do
         bytes: 2_000_000,
         selected: 1,
         torrent_hash: torrent.hash,
+        torrent_rd_id: torrent.rd_id,
         link: "https://real-debrid.com/link2"
       }
 

--- a/apps/vfs/lib/vfs.ex
+++ b/apps/vfs/lib/vfs.ex
@@ -11,7 +11,9 @@ defmodule VFS do
   alias VFS.Inode
   alias VFS.DirectoryEntry
   alias VFS.FileMode
-  alias SyncEngine.Schemas.Torrent
+
+  # Suppress warnings for SyncEngine module references (circular dependency at compile time, resolved at runtime)
+  @compile {:no_warn_undefined, SyncEngine.Torrents}
 
   @doc """
   Gets the root inode (inode_id=1).
@@ -325,12 +327,13 @@ defmodule VFS do
 
       # Update it
       updated_entry =
-      entry
-      |> DirectoryEntry.changeset(%{
-        parent_inode_id: new_parent_inode_id,
-        name: new_name
-      })
-      |> Repo.update!()
+        entry
+        |> DirectoryEntry.changeset(%{
+          parent_inode_id: new_parent_inode_id,
+          name: new_name
+        })
+        |> Repo.update!()
+
       {:ok, updated_entry}
     end)
   end

--- a/apps/vfs/lib/vfs/streamability.ex
+++ b/apps/vfs/lib/vfs/streamability.ex
@@ -60,6 +60,9 @@ defmodule VFS.Streamability do
 
   alias VFS.{Inode, Repo}
 
+  # Suppress warnings for SyncEngine module references (circular dependency at compile time, resolved at runtime)
+  @compile {:no_warn_undefined, SyncEngine.Torrents}
+
   @doc """
   Determines if an inode is streamable.
 

--- a/apps/vfs/priv/repo/migrations/20251222211305_add_foreign_key_cascade_to_torrent_files.exs
+++ b/apps/vfs/priv/repo/migrations/20251222211305_add_foreign_key_cascade_to_torrent_files.exs
@@ -12,6 +12,10 @@ defmodule VFS.Repo.Migrations.AddForeignKeyCascadeToTorrentFiles do
     # Add trigger to cascade delete torrent_files when torrent is deleted
     # SQLite doesn't support foreign keys on non-primary key columns easily,
     # so we use a trigger instead
+
+    # Make idempotent - drop if exists first
+    execute("DROP TRIGGER IF EXISTS delete_torrent_files_on_torrent_delete")
+
     execute("""
     CREATE TRIGGER delete_torrent_files_on_torrent_delete
     BEFORE DELETE ON torrents

--- a/apps/vfs/priv/repo/migrations/20251223195854_allow_multiple_torrents_per_hash.exs
+++ b/apps/vfs/priv/repo/migrations/20251223195854_allow_multiple_torrents_per_hash.exs
@@ -15,9 +15,6 @@ defmodule VFS.Repo.Migrations.AllowMultipleTorrentsPerHash do
   """
   use Ecto.Migration
 
-  import Ecto.Query
-  alias VFS.Repo
-
   def up do
     # ============================================================================
     # PART 1: Remove unique constraint on torrents.hash

--- a/apps/vfs/priv/repo/migrations/20251223195854_allow_multiple_torrents_per_hash.exs
+++ b/apps/vfs/priv/repo/migrations/20251223195854_allow_multiple_torrents_per_hash.exs
@@ -1,0 +1,252 @@
+defmodule VFS.Repo.Migrations.AllowMultipleTorrentsPerHash do
+  @moduledoc """
+  Migration to allow multiple torrent records with the same hash but different rd_ids.
+
+  This handles the real-world scenario where:
+  - Same content (same hash) is added multiple times to Real-Debrid with different rd_ids
+  - Different RD accounts add the same torrent
+  - Torrents are deleted and re-added, getting new rd_ids
+
+  Changes:
+  1. Remove UNIQUE constraint on torrents.hash (keep rd_id as UNIQUE)
+  2. Add torrent_rd_id field to torrent_files to track which torrent instance each file belongs to
+  3. Update unique constraint on torrent_files to (torrent_hash, torrent_rd_id, rd_id)
+  4. Backfill torrent_rd_id from existing data
+  """
+  use Ecto.Migration
+
+  import Ecto.Query
+  alias VFS.Repo
+
+  def up do
+    # ============================================================================
+    # PART 1: Remove unique constraint on torrents.hash
+    # ============================================================================
+    # SQLite doesn't support dropping constraints, so we recreate the table
+
+    create table(:torrents_new, primary_key: false) do
+      add(:id, :integer, primary_key: true)
+      add(:rd_id, :string, null: false)
+      add(:filename, :string, null: false)
+      add(:hash, :string, null: false)
+      add(:bytes, :bigint, null: false)
+      add(:host, :string)
+      add(:split, :integer)
+      add(:progress, :integer)
+      add(:status, :string)
+      add(:added, :string)
+      add(:ended, :string)
+      add(:speed, :integer)
+      add(:seeders, :integer)
+      add(:inode_id, references(:inodes, column: :inode_id, on_delete: :restrict))
+
+      # Deletion tracking fields
+      add(:deletion_status, :string)
+      add(:deletion_requested_at, :utc_datetime)
+      add(:deletion_attempts, :integer, default: 0)
+      add(:deletion_last_attempted_at, :utc_datetime)
+      add(:deletion_error, :string)
+
+      timestamps()
+    end
+
+    # Copy all data
+    execute("""
+    INSERT INTO torrents_new (
+      id, rd_id, filename, hash, bytes, host, split, progress, status,
+      added, ended, speed, seeders, inode_id,
+      deletion_status, deletion_requested_at, deletion_attempts,
+      deletion_last_attempted_at, deletion_error,
+      inserted_at, updated_at
+    )
+    SELECT
+      id, rd_id, filename, hash, bytes, host, split, progress, status,
+      added, ended, speed, seeders, inode_id,
+      deletion_status, deletion_requested_at, deletion_attempts,
+      deletion_last_attempted_at, deletion_error,
+      inserted_at, updated_at
+    FROM torrents
+    """)
+
+    # Drop old table and rename
+    drop(table(:torrents))
+    rename(table(:torrents_new), to: table(:torrents))
+
+    # Create indexes - rd_id is UNIQUE, hash is NOT unique (allows multiple torrents with same hash)
+    create(unique_index(:torrents, [:rd_id]))
+    create(index(:torrents, [:hash]))
+    create(index(:torrents, [:inode_id]))
+    create(index(:torrents, [:deletion_status]))
+
+    # ============================================================================
+    # PART 2: Add torrent_rd_id to torrent_files
+    # ============================================================================
+
+    # Create new torrent_files table with torrent_rd_id field
+    create table(:torrent_files_new) do
+      add(:rd_id, :integer, null: false)
+      add(:path, :text, null: false)
+      add(:bytes, :integer, null: false)
+      add(:selected, :integer, null: false)
+      add(:link, :text)
+      add(:torrent_hash, :string, null: false)
+      # NEW FIELD
+      add(:torrent_rd_id, :string, null: false)
+      add(:download_link, :text)
+      add(:link_expires_at, :utc_datetime)
+      add(:link_fetched_at, :utc_datetime)
+      add(:hardlink_count, :integer, null: false, default: 1)
+      add(:inode_id, references(:inodes, column: :inode_id, on_delete: :restrict))
+
+      timestamps()
+    end
+
+    # Copy data and backfill torrent_rd_id from torrents table
+    execute("""
+    INSERT INTO torrent_files_new (
+      id, rd_id, path, bytes, selected, link, torrent_hash, torrent_rd_id,
+      download_link, link_expires_at, link_fetched_at, hardlink_count,
+      inode_id, inserted_at, updated_at
+    )
+    SELECT
+      tf.id, tf.rd_id, tf.path, tf.bytes, tf.selected, tf.link,
+      tf.torrent_hash, t.rd_id as torrent_rd_id,
+      tf.download_link, tf.link_expires_at, tf.link_fetched_at, tf.hardlink_count,
+      tf.inode_id, tf.inserted_at, tf.updated_at
+    FROM torrent_files tf
+    JOIN torrents t ON t.hash = tf.torrent_hash
+    """)
+
+    # Drop old table and rename
+    drop(table(:torrent_files))
+    rename(table(:torrent_files_new), to: table(:torrent_files))
+
+    # Create new indexes - unique constraint is now (torrent_hash, torrent_rd_id, rd_id)
+    # This means: same file (rd_id) can exist under same hash, but only once per torrent instance
+    create(unique_index(:torrent_files, [:torrent_hash, :torrent_rd_id, :rd_id]))
+    create(index(:torrent_files, [:torrent_hash]))
+    create(index(:torrent_files, [:torrent_rd_id]))
+    create(index(:torrent_files, [:inode_id]))
+    create(index(:torrent_files, [:link_expires_at]))
+
+    # ============================================================================
+    # PART 3: Update cascade delete trigger for new schema
+    # ============================================================================
+    # Drop old trigger (from previous migration)
+    execute("DROP TRIGGER IF EXISTS delete_torrent_files_on_torrent_delete")
+
+    # Create new trigger that filters by both hash AND rd_id
+    execute("""
+    CREATE TRIGGER cascade_delete_torrent_files
+    AFTER DELETE ON torrents
+    FOR EACH ROW
+    BEGIN
+      DELETE FROM torrent_files WHERE torrent_hash = OLD.hash AND torrent_rd_id = OLD.rd_id;
+    END;
+    """)
+  end
+
+  def down do
+    # Drop the new trigger
+    execute("DROP TRIGGER IF EXISTS cascade_delete_torrent_files")
+
+    # Recreate old trigger (with old name)
+    execute("""
+    CREATE TRIGGER delete_torrent_files_on_torrent_delete
+    BEFORE DELETE ON torrents
+    FOR EACH ROW
+    BEGIN
+      DELETE FROM torrent_files WHERE torrent_hash = OLD.hash;
+    END;
+    """)
+
+    # Revert torrent_files schema (remove torrent_rd_id)
+    create table(:torrent_files_old) do
+      add(:rd_id, :integer, null: false)
+      add(:path, :text, null: false)
+      add(:bytes, :integer, null: false)
+      add(:selected, :integer, null: false)
+      add(:link, :text)
+      add(:torrent_hash, :string, null: false)
+      add(:download_link, :text)
+      add(:link_expires_at, :utc_datetime)
+      add(:link_fetched_at, :utc_datetime)
+      add(:hardlink_count, :integer, null: false, default: 1)
+      add(:inode_id, references(:inodes, column: :inode_id, on_delete: :restrict))
+
+      timestamps()
+    end
+
+    execute("""
+    INSERT INTO torrent_files_old (
+      id, rd_id, path, bytes, selected, link, torrent_hash,
+      download_link, link_expires_at, link_fetched_at, hardlink_count,
+      inode_id, inserted_at, updated_at
+    )
+    SELECT
+      id, rd_id, path, bytes, selected, link, torrent_hash,
+      download_link, link_expires_at, link_fetched_at, hardlink_count,
+      inode_id, inserted_at, updated_at
+    FROM torrent_files
+    """)
+
+    drop(table(:torrent_files))
+    rename(table(:torrent_files_old), to: table(:torrent_files))
+
+    create(unique_index(:torrent_files, [:torrent_hash, :rd_id]))
+    create(index(:torrent_files, [:torrent_hash]))
+    create(index(:torrent_files, [:inode_id]))
+    create(index(:torrent_files, [:link_expires_at]))
+
+    # Revert torrents schema (add back unique constraint on hash)
+    create table(:torrents_old, primary_key: false) do
+      add(:id, :integer, primary_key: true)
+      add(:rd_id, :string, null: false)
+      add(:filename, :string, null: false)
+      add(:hash, :string, null: false)
+      add(:bytes, :bigint, null: false)
+      add(:host, :string)
+      add(:split, :integer)
+      add(:progress, :integer)
+      add(:status, :string)
+      add(:added, :string)
+      add(:ended, :string)
+      add(:speed, :integer)
+      add(:seeders, :integer)
+      add(:inode_id, references(:inodes, column: :inode_id, on_delete: :restrict))
+
+      add(:deletion_status, :string)
+      add(:deletion_requested_at, :utc_datetime)
+      add(:deletion_attempts, :integer, default: 0)
+      add(:deletion_last_attempted_at, :utc_datetime)
+      add(:deletion_error, :string)
+
+      timestamps()
+    end
+
+    execute("""
+    INSERT INTO torrents_old (
+      id, rd_id, filename, hash, bytes, host, split, progress, status,
+      added, ended, speed, seeders, inode_id,
+      deletion_status, deletion_requested_at, deletion_attempts,
+      deletion_last_attempted_at, deletion_error,
+      inserted_at, updated_at
+    )
+    SELECT
+      id, rd_id, filename, hash, bytes, host, split, progress, status,
+      added, ended, speed, seeders, inode_id,
+      deletion_status, deletion_requested_at, deletion_attempts,
+      deletion_last_attempted_at, deletion_error,
+      inserted_at, updated_at
+    FROM torrents
+    """)
+
+    drop(table(:torrents))
+    rename(table(:torrents_old), to: table(:torrents))
+
+    create(unique_index(:torrents, [:rd_id]))
+    create(unique_index(:torrents, [:hash]))
+    create(index(:torrents, [:inode_id]))
+    create(index(:torrents, [:deletion_status]))
+  end
+end

--- a/apps/vfs/test/streamability_test.exs
+++ b/apps/vfs/test/streamability_test.exs
@@ -4,7 +4,6 @@ defmodule VFS.StreamabilityTest do
   alias VFS
   alias VFS.Streamability
   alias SyncEngine.Torrents
-  alias SyncEngine.Schemas.Torrent
 
   setup do
     # Explicitly get a connection checkout for the test
@@ -65,7 +64,8 @@ defmodule VFS.StreamabilityTest do
           bytes: 1_000_000,
           selected: 1,
           link: nil,
-          torrent_id: torrent.id,
+          torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           node_id: nil,
           hardlink_count: 1
         })
@@ -91,7 +91,8 @@ defmodule VFS.StreamabilityTest do
           bytes: 1_000_000,
           selected: 1,
           link: "https://example.com/download/streamable_file",
-          torrent_id: torrent.id,
+          torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           node_id: nil,
           hardlink_count: 1
         })
@@ -118,7 +119,8 @@ defmodule VFS.StreamabilityTest do
           bytes: 1_000_000,
           selected: 1,
           link: "https://example.com/download/preloaded_file",
-          torrent_id: torrent.id,
+          torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           node_id: nil,
           hardlink_count: 1
         })
@@ -147,7 +149,8 @@ defmodule VFS.StreamabilityTest do
           bytes: 1_000_000,
           selected: 1,
           link: "https://example.com/download",
-          torrent_id: torrent.id
+          torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id
         })
 
       assert Streamability.virtual_inode_streamable?(virtual_inode)
@@ -161,7 +164,8 @@ defmodule VFS.StreamabilityTest do
           bytes: 1_000_000,
           selected: 1,
           link: nil,
-          torrent_id: torrent.id
+          torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id
         })
 
       refute Streamability.virtual_inode_streamable?(virtual_inode)
@@ -206,7 +210,8 @@ defmodule VFS.StreamabilityTest do
           bytes: 1_000_000,
           selected: 1,
           link: "https://example.com/file1",
-          torrent_id: torrent.id,
+          torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           hardlink_count: 1
         })
 
@@ -241,7 +246,8 @@ defmodule VFS.StreamabilityTest do
           bytes: 1_000_000,
           selected: 1,
           link: "https://example.com/shared",
-          torrent_id: torrent.id,
+          torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           hardlink_count: 3
         })
 
@@ -283,7 +289,8 @@ defmodule VFS.StreamabilityTest do
           bytes: 1_000_000,
           selected: 1,
           link: "https://example.com/idempotent",
-          torrent_id: torrent.id,
+          torrent_hash: torrent.hash,
+          torrent_rd_id: torrent.rd_id,
           hardlink_count: 1
         })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking multiple torrent instances with identical content hashes independently.
  * Implemented centralized deletion policy for consistent torrent cleanup decisions.
  * Added inode update capability to point to the most recent file version across torrent instances.

* **Bug Fixes**
  * Improved handling of file hardlink tracking when multiple torrent instances coexist.

* **Refactor**
  * Migrated deletion and cleanup operations to use Real-Debrid identifiers for more reliable torrent management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->